### PR TITLE
Feat/dash

### DIFF
--- a/frontend/lib/Constants/colors.dart
+++ b/frontend/lib/Constants/colors.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  // 기본 색상
+  static const Color mainColor = Color(0xFF43C1CD);
+  static const Color greyBox = Color.fromARGB(255, 240, 240, 240);
+
+  // 텍스트 색상
+  static const Color textBlack = Color(0xFF212121);
+  static const Color textWhite = Color.fromARGB(255, 255, 255, 255);
+
+  // 경고 및 상태 색상
+  static const Color success = Color(0xFF4CAF50);
+
+  // 점수 상태 색상
+  static const Color positiveScore = Color(0xFFDCFCDB); // 긍정적인 점수 (연한 초록색)
+  static const Color negativeScore = Color(0xFFFFB8B8); // 부정적인 점수 (연한 빨간색)
+  static const Color negative = Color(0xFFFF7778);
+
+  // 기타 색상
+  static const Color progressBar = Color(0xFFE0E0E0); // 프로그래스 바 배경색
+  static const Color divider = Color(0xFFBDBDBD); // 구분선 색상
+}

--- a/frontend/lib/buttonLayout/mainButton.dart
+++ b/frontend/lib/buttonLayout/mainButton.dart
@@ -19,7 +19,7 @@ class MainButton extends StatelessWidget {
         backgroundColor: AppColors.mainColor,
         padding: const EdgeInsets.symmetric(vertical: 15),
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(25),
+          borderRadius: BorderRadius.circular(20),
         ),
       ),
       child: SizedBox(
@@ -30,6 +30,7 @@ class MainButton extends StatelessWidget {
             style: const TextStyle(
               fontSize: 18,
               color: AppColors.textWhite,
+              fontWeight: FontWeight.w600,
             ),
           ),
         ),

--- a/frontend/lib/buttonLayout/mainButton.dart
+++ b/frontend/lib/buttonLayout/mainButton.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/Constants/colors.dart';
+
+class MainButton extends StatelessWidget {
+  final String text; // 버튼에 표시할 텍스트
+  final VoidCallback onPressed; // 버튼 클릭 시 실행할 함수
+
+  const MainButton({
+    super.key,
+    required this.text,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppColors.mainColor,
+        padding: const EdgeInsets.symmetric(vertical: 15),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(25),
+        ),
+      ),
+      child: SizedBox(
+        width: double.infinity,
+        child: Center(
+          child: Text(
+            text,
+            style: const TextStyle(
+              fontSize: 18,
+              color: AppColors.textWhite,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/buttonLayout/text.dart
+++ b/frontend/lib/buttonLayout/text.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/Constants/colors.dart';
+
+class TitleText extends StatelessWidget {
+  final String text; // 표시할 텍스트
+
+  const TitleText({
+    super.key,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        fontSize: 30,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+}
+
+class ContentText extends StatelessWidget {
+  final String text; // 표시할 텍스트
+
+  const ContentText({
+    super.key,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        fontSize: 20,
+        color: AppColors.textBlack,
+      ),
+    );
+  }
+}

--- a/frontend/lib/dash.dart
+++ b/frontend/lib/dash.dart
@@ -1,15 +1,163 @@
-// dash.dart
 import 'package:flutter/material.dart';
+import 'package:frontend/Constants/colors.dart';
+import 'package:frontend/buttonLayout/mainButton.dart';
+import 'package:frontend/buttonLayout/text.dart';
 
-class DashPage extends StatelessWidget {
+class DashPage extends StatefulWidget {
+  const DashPage({super.key});
+
+  @override
+  State<DashPage> createState() => _DashPageState();
+}
+
+class _DashPageState extends State<DashPage> {
+  DateTime selectedDate = DateTime(2024, 8, 20);
+
+// 더미 데이터
+  final Map<DateTime, Map<String, int>> skinData = {
+    DateTime(2024, 8, 20): {
+      "수분": 21,
+      "모공": 27,
+      "여드름": 74,
+      "주름": 57,
+      "색소침착": 32,
+    },
+    DateTime(2024, 8, 21): {
+      "수분": 25,
+      "모공": 30,
+      "여드름": 70,
+      "주름": 55,
+      "색소침착": 28,
+    },
+    DateTime(2024, 8, 22): {
+      "수분": 18,
+      "모공": 25,
+      "여드름": 80,
+      "주름": 60,
+      "색소침착": 40,
+    },
+  };
+
+  void updateDate(int days) {
+    setState(() {
+      selectedDate = selectedDate.add(Duration(days: days));
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
+    final currentData = skinData[selectedDate] ?? {};
+
     return Scaffold(
-      appBar: AppBar(
-        title: Text('Dash Page'),
-      ),
-      body: Center(
-        child: Text('대시보드 화면!'),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 80),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const TitleText(text: "DSPT 유지민님의\n피부 데이터"),
+
+            const SizedBox(height: 10),
+
+            const ContentText(
+              text: "유지민님의 피부는 어쩌고 저쩌고\n오늘도 화이팅!",
+            ),
+            const SizedBox(height: 20),
+
+            MainButton(text: "루틴 시작하기", onPressed: () {}),
+            const SizedBox(height: 10),
+            MainButton(text: "오늘 피부 기록하기", onPressed: () {}),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                TextButton(
+                  onPressed: () {
+                    // 통합 결과
+                  },
+                  child: const ContentText(
+                    text: "통합 결과",
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    // 결과 통계
+                  },
+                  child: const ContentText(
+                    text: "결과 통계",
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    // 보유 제품 관리
+                  },
+                  child: const ContentText(
+                    text: "보유 제품 관리",
+                  ),
+                ),
+              ],
+            ),
+
+            const SizedBox(height: 10),
+            // 날짜 변경 버튼과 표시
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.chevron_left),
+                  onPressed: () => updateDate(-1),
+                ),
+                Text(
+                  "${selectedDate.year}.${selectedDate.month.toString().padLeft(2, '0')}.${selectedDate.day.toString().padLeft(2, '0')}",
+                  style: const TextStyle(fontSize: 16),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.chevron_right),
+                  onPressed: () => updateDate(1),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            // 데이터 출력
+            if (currentData.isNotEmpty)
+              Container(
+                padding: const EdgeInsets.all(20),
+                decoration: BoxDecoration(
+                  color: AppColors.greyBox,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Column(
+                  children: currentData.entries.map((entry) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 5),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            entry.key,
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                          Expanded(
+                            child: LinearProgressIndicator(
+                              value: entry.value / 100,
+                              color: entry.key == "여드름" || entry.key == "주름"
+                                  ? AppColors.positiveScore
+                                  : AppColors.negativeScore,
+                              backgroundColor: Colors.white,
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                          Text("${entry.value}점"),
+                        ],
+                      ),
+                    );
+                  }).toList(),
+                ),
+              )
+            else
+              const Text("데이터가 없습니다."),
+          ],
+        ),
       ),
     );
   }

--- a/frontend/lib/dash.dart
+++ b/frontend/lib/dash.dart
@@ -13,7 +13,8 @@ class DashPage extends StatefulWidget {
 class _DashPageState extends State<DashPage> {
   DateTime selectedDate = DateTime(2024, 8, 20);
 
-// 더미 데이터
+  final int criterion = 50;
+// 더미 데이터 : 나중에 class 분리 예정.
   final Map<DateTime, Map<String, int>> skinData = {
     DateTime(2024, 8, 20): {
       "수분": 21,
@@ -32,7 +33,7 @@ class _DashPageState extends State<DashPage> {
     DateTime(2024, 8, 22): {
       "수분": 18,
       "모공": 25,
-      "여드름": 80,
+      "여드름": 20,
       "주름": 60,
       "색소침착": 40,
     },
@@ -50,23 +51,21 @@ class _DashPageState extends State<DashPage> {
 
     return Scaffold(
       body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 80),
+        padding:
+            const EdgeInsets.only(left: 30, right: 30, top: 60, bottom: 30),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const TitleText(text: "DSPT 유지민님의\n피부 데이터"),
-
             const SizedBox(height: 10),
-
-            const ContentText(
-              text: "유지민님의 피부는 어쩌고 저쩌고\n오늘도 화이팅!",
-            ),
+            const ContentText(text: "유지민님의 피부는 어쩌고 저쩌고\n오늘도 화이팅!"),
             const SizedBox(height: 20),
 
             MainButton(text: "루틴 시작하기", onPressed: () {}),
             const SizedBox(height: 10),
             MainButton(text: "오늘 피부 기록하기", onPressed: () {}),
             const SizedBox(height: 20),
+
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
@@ -74,25 +73,19 @@ class _DashPageState extends State<DashPage> {
                   onPressed: () {
                     // 통합 결과
                   },
-                  child: const ContentText(
-                    text: "통합 결과",
-                  ),
+                  child: const ContentText(text: "통합 결과"),
                 ),
                 TextButton(
                   onPressed: () {
                     // 결과 통계
                   },
-                  child: const ContentText(
-                    text: "결과 통계",
-                  ),
+                  child: const ContentText(text: "결과 통계"),
                 ),
                 TextButton(
                   onPressed: () {
                     // 보유 제품 관리
                   },
-                  child: const ContentText(
-                    text: "보유 제품 관리",
-                  ),
+                  child: const ContentText(text: "보유 제품 관리"),
                 ),
               ],
             ),
@@ -108,7 +101,10 @@ class _DashPageState extends State<DashPage> {
                 ),
                 Text(
                   "${selectedDate.year}.${selectedDate.month.toString().padLeft(2, '0')}.${selectedDate.day.toString().padLeft(2, '0')}",
-                  style: const TextStyle(fontSize: 16),
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
                 IconButton(
                   icon: const Icon(Icons.chevron_right),
@@ -116,8 +112,6 @@ class _DashPageState extends State<DashPage> {
                 ),
               ],
             ),
-            const SizedBox(height: 20),
-
             // 데이터 출력
             if (currentData.isNotEmpty)
               Container(
@@ -127,27 +121,39 @@ class _DashPageState extends State<DashPage> {
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start, // 왼쪽 정렬
                   children: currentData.entries.map((entry) {
                     return Padding(
                       padding: const EdgeInsets.symmetric(vertical: 5),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                            entry.key,
-                            style: const TextStyle(fontSize: 16),
+                          Row(
+                            children: [
+                              Text(
+                                entry.key,
+                                style: const TextStyle(fontSize: 16),
+                              ),
+                              const SizedBox(width: 7),
+                              Text(
+                                "${entry.value}점",
+                                style: const TextStyle(
+                                  fontSize: 20,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ],
                           ),
-                          Expanded(
-                            child: LinearProgressIndicator(
-                              value: entry.value / 100,
-                              color: entry.key == "여드름" || entry.key == "주름"
-                                  ? AppColors.positiveScore
-                                  : AppColors.negativeScore,
-                              backgroundColor: Colors.white,
-                            ),
+                          const SizedBox(height: 7),
+                          LinearProgressIndicator(
+                            value: entry.value / 100,
+                            color: entry.value >= criterion // 기준 점수에 따른 색상
+                                ? AppColors.positiveScore
+                                : AppColors.negativeScore,
+                            backgroundColor: Colors.white,
+                            minHeight: 20,
+                            borderRadius: BorderRadius.circular(30),
                           ),
-                          const SizedBox(width: 10),
-                          Text("${entry.value}점"),
                         ],
                       ),
                     );

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -25,9 +25,9 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       theme: ThemeData(primarySwatch: Colors.blue),
       //home 변경할때, 주석처리로!
-      home: LoadingPage0(), //로딩 페이지 0 (로그인 후 첫화면)
+      //home: LoadingPage0(), //로딩 페이지 0 (로그인 후 첫화면)
       // home : LoadingPage1(),
-      //home: DashPage(),
+      home: const DashPage(), // 피부 측정 기록과 루틴 기록이 하나라도 있을 때의 메인화면
       //home: LoginPage(), // 로그인 페이지
       //home: RoutinePage() // 루틴 페이지
       //home : const AddSkinCareMain() // 제품 등록 페이지


### PR DESCRIPTION
### 코드 변경 이유
대시보드 UI 구현 완료.
해당 UI는 사용자가 피부 인식과 루틴 추천을 1회 이상 받았을 시, 앱 접속 후 처음 보여지는 이미지이다.
<br>

### 리뷰어가 집중할 부분
자주 사용하는 색상을 가져다 쓰기 편리하도록 colors.dart 생성.    
자주 사용하는 버튼도 가져다 쓰기 편리하도록 buttonLayout 생성.    
자주 사용하는 text 양식도 text.dart 생성    
**코드 길이 축소와 가독성에 도움이 많이 되니, 많이 사용하는 요소 있으면 새로 생성하거나 이미 만들어 둔 거 가져다 쓰는 것이 좋을 듯 함.**           
<br>

### 스크린샷
![Screenshot_20241120_010448](https://github.com/user-attachments/assets/4cb02051-6cd8-4374-abde-834da35dd9f3)
<br>

### 그외 남은 구현 사항
통합 결과, 결과 통계, 보유제품 관리 onPressd() 추가 필요.
<br>
