### PR TITLE
feat : 민감성 여부 push 함수 구현, 회원가입 창 나이 필드 추가

### DIFF
--- a/frontend/lib/Constants/sensitive_put.dart
+++ b/frontend/lib/Constants/sensitive_put.dart
@@ -1,0 +1,33 @@
+import 'dart:convert'; // JSON 변환에 사용
+import 'package:frontend/Constants/user_data.dart';
+import 'package:http/http.dart' as http; // HTTP 요청에 사용
+
+Future<void> updateSensitiveSkinStatus(bool hasSensitiveSkin, UserData userData) async {
+  final url = Uri.parse('http://3.34.5.57/users/${userData.id}'); // 백엔드 주소를 넣어주세요
+  final headers = {'Content-Type': 'application/json'};
+  final body = jsonEncode({'has_sensitive_skin': hasSensitiveSkin});
+
+  try {
+    final response = await http.put(
+      url,
+      headers: headers,
+      body: body,
+    );
+
+    switch (response.statusCode) {
+      case 200:
+        print('성공적으로 업데이트되었습니다.');
+        break;
+      case 404:
+        print('백엔드 엔드포인트를 찾을 수 없습니다.');
+        break;
+      case 402:
+        print('유효성 검사 오류입니다. 입력 값을 확인하세요.');
+        break;
+      default:
+        print('오류 발생: ${response.statusCode}, ${response.body}');
+    }
+  } catch (e) {
+    print('요청 중 오류가 발생했습니다: $e');
+  }
+}

--- a/frontend/lib/Constants/user_data.dart
+++ b/frontend/lib/Constants/user_data.dart
@@ -9,6 +9,7 @@ class UserData {
   final DateTime updatedAt;
   final String hashedPassword;
   final String bsti;
+  final bool sensitive;
 
   UserData({
     required this.email,
@@ -21,47 +22,50 @@ class UserData {
     required this.updatedAt,
     required this.hashedPassword,
     required this.bsti,
+    required this.sensitive,
   });
 
-  factory UserData.fromJson(Map<String, dynamic> json) {
-    return UserData(
-      email: json['email'] ?? '',
-      name: json['name'] ?? '',
-      id: json['_id'] ?? '',
-      skinType: json['skin_type'] ?? '',
-      skinConcerns: json['skin_concerns'] is Iterable
-          ? List<String>.from(json['skin_concerns'])
-          : [],
-      avoidIngredients: json['avoid_ingredients'] is Map
-          ? Map<String, Map<String, int>>.from(
-              json['avoid_ingredients'].map((key, value) {
-                return MapEntry(
-                  key,
-                  value is Map
-                      ? Map<String, int>.from(value)
-                      : {}, // 비어 있는 Map 기본값
-                );
-              }),
-            )
-          : {},
-      createdAt: json['created_at'] != null
-          ? DateTime.parse(json['created_at'])
-          : DateTime.now(),
-      updatedAt: json['updated_at'] != null
-          ? DateTime.parse(json['updated_at'])
-          : DateTime.now(),
-      hashedPassword: json['hashed_password'] ?? '',
-      bsti: json['bsti'] ?? '',
-    );
-  }
+factory UserData.fromJson(Map<String, dynamic> json) {
+  return UserData(
+    email: json['email'] ?? '',
+    name: json['name'] ?? '',
+    id: json['_id'] ?? '',
+    skinType: json['skin_type'] ?? '',
+    skinConcerns: json['skin_concerns'] is Iterable
+        ? List<String>.from(json['skin_concerns'])
+        : [],
+    sensitive: (json['has_sensitive_skin'] is bool)
+        ? json['has_sensitive_skin'] as bool
+        : false, // null 또는 빈 문자열은 false로 처리
+    avoidIngredients: json['avoid_ingredients'] is Map
+        ? Map<String, Map<String, int>>.from(
+            json['avoid_ingredients'].map((key, value) {
+              return MapEntry(
+                key,
+                value is Map ? Map<String, int>.from(value) : {},
+              );
+            }),
+          )
+        : {},
+    createdAt: json['created_at'] != null
+        ? DateTime.parse(json['created_at'])
+        : DateTime.now(),
+    updatedAt: json['updated_at'] != null
+        ? DateTime.parse(json['updated_at'])
+        : DateTime.now(),
+    hashedPassword: json['hashed_password'] ?? '',
+    bsti: json['bsti'] ?? '',
+  );
+}
+
 }
 
 bool isUserDataEmpty(UserData userData) {
   return userData.email.isEmpty &&
       userData.name.isEmpty &&
       userData.id.isEmpty &&
-      userData.skinType.isEmpty &&
-      userData.skinConcerns.isEmpty &&
-      userData.avoidIngredients.isEmpty &&
-      userData.hashedPassword.isEmpty;
+      userData.avoidIngredients.isEmpty && 
+      userData.hashedPassword.isEmpty &&
+      userData.bsti.isEmpty;
 }
+

--- a/frontend/lib/Constants/which_bsti.dart
+++ b/frontend/lib/Constants/which_bsti.dart
@@ -1,25 +1,26 @@
+import 'package:frontend/Constants/sensitive_put.dart';
+import 'package:frontend/Constants/user_data.dart';
 import 'package:frontend/survey/survey_info.dart';
 
 class DecideBSTI {
-  static String whichBSTI(SurveyInfo surveyInfo) {
+  static String whichBSTI(SurveyInfo surveyInfo, UserData userData) {
     String DO, RS, PN, WT;
     // 설문과 모델 값을 조정하여 bsti 결정.
 
 // D:건성	O:지성
 
-
 // R:민감x	S:민감성
     if (surveyInfo.sensitive1 || surveyInfo.sensitive2) {
+      updateSensitiveSkinStatus(true, userData);
       RS = "S";
     } else {
+      updateSensitiveSkinStatus(false, userData);
       RS = "R";
     }
 
 // P:색소침착o	N:색소침착x
 
-
 // W:탄력x	T: 탄력o
-
 
     //return ("$DO$RS$PN$WT");
     return RS;

--- a/frontend/lib/logIn/register_post.dart
+++ b/frontend/lib/logIn/register_post.dart
@@ -4,13 +4,15 @@ import 'package:frontend/Constants/user_data.dart';
 import 'package:http/http.dart' as http; // HTTP 요청을 위해 필요
 
 Future<UserData?> userRegister(
-    String name, String email, String password) async {
+    String name, String email, String password, int age) async {
   final url = Uri.parse('http://3.34.5.57/users/'); // 백엔드의 엔드포인트
   final headers = {'Content-Type': 'application/json'}; // 요청 헤더 설정
   final body = jsonEncode({
     "email": email,
+    "age" : age,
     "name": name,
     "password": password,
+
   }); // 요청 body 생성
 
   try {

--- a/frontend/lib/logIn/signup_input.dart
+++ b/frontend/lib/logIn/signup_input.dart
@@ -13,6 +13,7 @@ class SignupInput extends StatelessWidget {
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _ageController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +41,7 @@ class SignupInput extends StatelessWidget {
                         'assets/BBImask.png',
                         height: (MediaQuery.of(context).size.height -
                                 MediaQuery.of(context).viewInsets.bottom) *
-                            0.25,
+                            0.15,
                       ),
                       const Text(
                         "Sign up",
@@ -67,6 +68,11 @@ class SignupInput extends StatelessWidget {
                         keyboardType: TextInputType.text,
                         obscureText: true, // 비밀번호 안보이도록 하는 것
                       ),
+                                            TextField(
+                        controller: _ageController,
+                        decoration: const InputDecoration(labelText: '나이 (숫자만 입력)'),
+                        keyboardType: TextInputType.number,
+                      ),
                       SizedBox(
                         height: (MediaQuery.of(context).size.height -
                                 MediaQuery.of(context).viewInsets.bottom) *
@@ -77,10 +83,11 @@ class SignupInput extends StatelessWidget {
                           final userData = await userRegister(
                               _nameController.text,
                               _emailController.text,
-                              _passwordController.text);
+                              _passwordController.text,
+                              int.parse(_ageController.text));
                           if (userData != null && !isUserDataEmpty(userData)) {
                             print("회원가입 성공! $userData");
-                             Navigator.push(
+                            Navigator.push(
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) => LoadingPage0(userData),
@@ -88,7 +95,7 @@ class SignupInput extends StatelessWidget {
                           }
                         },
                         style: ElevatedButton.styleFrom(
-                            backgroundColor: AppColors.mainColor),
+                            backgroundColor: AppColors.mainColor,),
                         child: const Icon(
                           Icons.arrow_forward,
                           color: Colors.white,

--- a/frontend/lib/survey/survey4.dart
+++ b/frontend/lib/survey/survey4.dart
@@ -67,7 +67,7 @@ class _Survey4State extends State<Survey4> {
                   if (_selectedOption != null) {
                     // "네"면 pizi = true, "아니오"면 pizi = false
                     widget.surveyInfo.pizi = (_selectedOption == '네');
-                    final String userBSTI = DecideBSTI.whichBSTI(widget.surveyInfo);
+                    final String userBSTI = DecideBSTI.whichBSTI(widget.surveyInfo, widget.userData);
                     // 위 userBSTI string을 사용자 정보로 push하는 api 추가
                     Navigator.push(
                       context,


### PR DESCRIPTION
### 코드 변경 이유
설문을 통한 민감성 push
회원가입 창 나이 칸 추가
<br>

### 발견된 위험이나 장애
로그인 및 회원가입 입력 시 하나라도 입력 안 하면 넘어가지 못하도록 예외처리 필요
<br>


### 스크린샷
![image](https://github.com/user-attachments/assets/8d31357c-dd46-421d-b827-a0c5dcc96b1d)

<br>

### 그외 남은 구현 사항
- [ ]  여드름 연결하기
- [ ]  점수 기준점 토대로 bsti 판별 함수
- [ ]  루틴 아이디 있으면 바로 대시보드로
- [ ]  앱 아이콘 넣기
- [ ]  회원가입과 로그인창에 아무것도 안 하고 눌렀을 때 예외처리
<br>
